### PR TITLE
fix-cable-boxes

### DIFF
--- a/fritz_export_helper.py
+++ b/fritz_export_helper.py
@@ -1,0 +1,23 @@
+import argparse
+from fritzconnection import FritzConnection
+from fritzconnection.core.exceptions import ActionError, ServiceError
+from pprint import pprint
+
+parser = argparse.ArgumentParser(description='Check actions against Fritz TR-064 API and pretty print the results.')
+parser.add_argument('fritz_ip', help='Fritz Device IP Address')
+parser.add_argument('username', help='Username of a user on the Fritz device.')
+parser.add_argument('password', help='Password of the user on the Fritz device.')
+parser.add_argument('service', help='Username of a user on the Fritz device.')
+parser.add_argument('action', help='Username of a user on the Fritz device.')
+
+args = parser.parse_args()
+
+#print(f'Would call IP: {args.fritz_ip}, user: {args.username}, password: {args.password}, service: {args.service}, action: {args.action}')
+fc = FritzConnection(address=args.fritz_ip, user=args.username, password=args.password)
+
+try:
+    result = fc.call_action(args.service, args.action)
+    print('--------------------------------\nRESULT:')
+    pprint(result)
+except (ServiceError, ActionError) as e:
+    print(f'Calling service {args.service} with action {args.action} returned an error: {e}')

--- a/fritzexporter/fritzcapabilities.py
+++ b/fritzexporter/fritzcapabilities.py
@@ -1,6 +1,7 @@
 import logging
 from abc import ABC, abstractclassmethod, abstractmethod
 
+from fritzconnection.core.exceptions import ActionError, ServiceError
 from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
 
 logger = logging.getLogger(__name__)
@@ -21,6 +22,16 @@ class FritzCapability(ABC):
     def checkCapability(self, device):
         self.present = all([ (service in device.fc.services) and (action in device.fc.services[service].actions) for (service, action) in self.requirements ])
         logger.debug(f'Capability {type(self).__name__} set to {self.present} on device {device.host}')
+
+        # It seems some boxes report service/actions they don't actually support. So try calling the requirements, and if it throws "InvalidService" or "InvalidAction", disable this again.
+        if self.present:
+            for (svc, action) in self.requirements:
+                try:
+                    device.fc.call_action(svc, action)
+                except (ServiceError, ActionError) as e:
+                    logger.warn(f'disabling metrics at service {svc}, action {action} - fritzconnection.call_action returned {e}')
+                    self.present = False
+
 
     def getMetrics(self, devices, name):
         for device in devices:

--- a/fritzexporter/fritzcapabilities.py
+++ b/fritzexporter/fritzcapabilities.py
@@ -200,7 +200,7 @@ class WanDSLInterfaceConfig(FritzCapability):
 
     def _getMetricValues(self, device):
         fritz_dslinfo_result = device.fc.call_action('WANDSLInterfaceConfig:1', 'GetInfo')
-        self.metrics['enable'] .add_metric([device.serial], fritz_dslinfo_result['NewEnable'])
+        self.metrics['enable'].add_metric([device.serial], fritz_dslinfo_result['NewEnable'])
         
         dslstatus = 1 if fritz_dslinfo_result['NewStatus'] == 'Up' else 0
         self.metrics['status'].add_metric([device.serial], dslstatus)


### PR DESCRIPTION
This script can be used to call actions without arguments and will pretty
print the results.

Also be more defensive about the reported Services and actions: Instead of erroring out, log a warning