### PR TITLE
Allow both single and multiple environment variables for Kubernetes deployment

### DIFF
--- a/.github/workflows/build-and-push-develop.yaml
+++ b/.github/workflows/build-and-push-develop.yaml
@@ -1,9 +1,9 @@
 name: Build Dev Docker image
 
 on:
-  pull_request:
+  push:
     branches:
-    - master
+    - develop
 
 jobs:
   build-docker:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 .vscode
 launch.json
 settings.json
+.idea

--- a/fritz_exporter.py
+++ b/fritz_exporter.py
@@ -28,12 +28,10 @@ logger.setLevel(logging.WARN)
 
 
 def main():
-    fritz_config_env = os.getenv('FRITZ_EXPORTER_CONFIG')
-    if fritz_config_env is None:
-        logger.critical('FRITZ_EXPORTER_CONFIG is not set. Exiting.')
-        sys.exit(1)
-    else:
-        fritzcollector = FritzCollector()
+    fritzcollector = FritzCollector()
+
+    if 'FRITZ_EXPORTER_CONFIG' in os.environ:
+        fritz_config_env = os.getenv('FRITZ_EXPORTER_CONFIG')
         fritz_config = [x.strip() for x in fritz_config_env.split(',')]
         configs = int(len(fritz_config) / 3)
         for device in range(configs):
@@ -41,6 +39,14 @@ def main():
             username = fritz_config.pop(0)
             password = fritz_config.pop(0)
             fritzcollector.register(FritzDevice(address, username, password))
+    elif 'FRITZ_HOSTNAME' and 'FRITZ_USERNAME' and 'FRITZ_PASSWORD' in os.environ:
+        address = os.getenv('FRITZ_HOSTNAME')
+        username = os.getenv('FRITZ_USERNAME')
+        password = os.getenv('FRITZ_PASSWORD')
+        fritzcollector.register(FritzDevice(address, username, password))
+    else:
+        logger.critical('no ENV variables set. Exiting.')
+        sys.exit(1)
 
     REGISTRY.register(fritzcollector)
 

--- a/fritz_exporter.py
+++ b/fritz_exporter.py
@@ -16,8 +16,6 @@ import asyncio
 import logging
 import os
 import sys
-import time
-from pprint import pprint
 
 from prometheus_client import start_http_server
 from prometheus_client.core import REGISTRY
@@ -28,20 +26,21 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARN)
 
+
 def main():
     fritz_config_env = os.getenv('FRITZ_EXPORTER_CONFIG')
-    if fritz_config_env == None:
+    if fritz_config_env is None:
         logger.critical('FRITZ_EXPORTER_CONFIG is not set. Exiting.')
         sys.exit(1)
     else:
-        fritz_config = [ x.strip() for x in fritz_config_env.split(',') ]
-        # if the next idiom looks like magic: https://stackoverflow.com/questions/23286254/how-to-convert-a-list-to-a-list-of-tuples
-        conf_it = [iter(fritz_config)] * 3
-        device_config = zip(*conf_it) # now tuples of (host, user, password)
-
-    fritzcollector = FritzCollector()
-    for device in device_config:
-        fritzcollector.register(FritzDevice(device[0], device[1], device[2]))
+        fritzcollector = FritzCollector()
+        fritz_config = [x.strip() for x in fritz_config_env.split(',')]
+        configs = int(len(fritz_config) / 3)
+        for device in range(configs):
+            address = fritz_config.pop(0)
+            username = fritz_config.pop(0)
+            password = fritz_config.pop(0)
+            fritzcollector.register(FritzDevice(address, username, password))
 
     REGISTRY.register(fritzcollector)
 
@@ -55,6 +54,6 @@ def main():
     finally:
         loop.close()
 
+
 if __name__ == '__main__':
     main()
-


### PR DESCRIPTION
This PR implements the ability to use either a single environment variable to monitor multiple devices or use multiple environment variables for easy use in a kubernetes deployment. This way you can store the password in a kubernetes secret. You lose the ability to monitor more than one device but can spawn multiple deployments for that purpose. I added a section to the Readme how to utilize this.