### PR TITLE
Make nvironment configuration more kubernetes friendly

### DIFF
--- a/.github/workflows/build-and-push-develop.yaml
+++ b/.github/workflows/build-and-push-develop.yaml
@@ -1,9 +1,9 @@
 name: Build Dev Docker image
 
 on:
-  pull_request:
+  push:
     branches:
-    - master
+    - develop
 
 jobs:
   build-docker:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 .vscode
 launch.json
 settings.json
+.idea


### PR DESCRIPTION
This release ads the ability to specify configuration in separate Env Vars, to make it easier to put the passwords into a kubernetes secret.

If using this you are currently only able to monitor a single device, but if you are running k8s you can simply deploy multiple exporters to monitor multiple devices.

Thanks to @transacid for the PR.