### PR TITLE
explicitly cast server port to an int

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,13 +159,13 @@ spec:
         image: pdreker/fritz_exporter:latest
         imagePullPolicy: Always
         env:
-        - name:  FRITZ_HOST
+        - name:  FRITZ_HOSTNAME
           value: "192.168.178.1"
-        - name:  FRITZ_USER
+        - name:  FRITZ_USERNAME
           value: "monitoring"
         - name:  FRITZ_EXPORTER_PORT
           value: "9787"
-        - name:  FRITZ_PASS
+        - name:  FRITZ_PASSWORD
           valueFrom:
             secretKeyRef:
               name: fritzbox-password

--- a/fritz_exporter.py
+++ b/fritz_exporter.py
@@ -52,7 +52,7 @@ def main():
 
     port = os.getenv('FRITZ_EXPORTER_PORT', 9787)
     logger.info(f'Starting listener at {port}')
-    start_http_server(port)
+    start_http_server(int(port))
 
     loop = asyncio.get_event_loop()
     try:


### PR DESCRIPTION
Kubernetes only allows strings in env variables. Explicitly casting server port to and int doesn't hurt when it's already an int but let's you change the port in kubernetes.

also fixed a c&p fail with the names of the env variables in the Readme