### PR TITLE
New metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It has been tested against an AVM Fritz!Box 7590 (DSL), a Fritz!Repeater 2400 an
 
 ## WARNING
 
-This current version of the exporter has completely reworked how this exports metrics! If you have used this exporter in the past, you will get a completely new set of metrics.
+This current version (1.0.0 and later) of the exporter has completely reworked how this exports metrics! If you have used this exporter in the past, you will get a completely new set of metrics.
 
 ### Changes
 
@@ -32,6 +32,10 @@ The following groups of metrics are currently available:
 Thre is code in `fritzexporter/fritzcapabilities.py` to extract information about ever single host the device knows about but it is completely disabled as of now as polling the information can take 20-30 seconds depending on your network setup. If you want to test this out simply uncomment that code and rebuild the docker image.
 
 If there is any information missing or not displayed on your specific device, please open an issue.
+
+## Known problems
+
+* It seems like Fritz!OS does not internally count the packets for the Guest WiFi. So even though those counters are there they are always 0. This seems to be a problem with Fritz!OS and not the exporter. The counters are delivered nontheless, just in case this gets fixed by AVM.
 
 ## Grafana Dashboard
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The following groups of metrics are currently available:
 * WiFi statistics
 * WAN Layer1 (physical link) statistics
 
-Thre is code in `fritzexporter/fritzcapabilities.py` to extract information about ever single host the device knows about but it is completely disabled as of now as polling the information can take 20-30 seconds depending on your network setup. If you want to test this out simply uncomment that code and rebuild the docker image.
+There is code in `fritzexporter/fritzcapabilities.py` to extract information about ever single host the device knows about but it is completely disabled as of now as polling the information can take 20-30 seconds depending on your network setup. If you want to test this out simply uncomment that code and rebuild the docker image.
 
 If there is any information missing or not displayed on your specific device, please open an issue.
 

--- a/fritzexporter/fritzcapabilities.py
+++ b/fritzexporter/fritzcapabilities.py
@@ -154,8 +154,8 @@ class UserInterface(FritzCapability):
 
     def _getMetricValues(self, device):
         update_result = device.fc.call_action('UserInterface:1', 'GetInfo')
-        upd_available = 1 if update_result['NewUpgradeAvailable'] == '1' else 0
-        new_software_version = "n/a" if update_result['NewX_AVM-DE_Version'] is None else update_result['NewX_AVM-DE_Version']
+        upd_available = 1 if update_result['NewUpgradeAvailable'] else 0
+        new_software_version = "n/a" if update_result['NewUpgradeAvailable'] else update_result['NewX_AVM-DE_Version']
         self.metrics['update'].add_metric([device.serial, new_software_version], upd_available)
         yield self.metrics['update']
 

--- a/fritzexporter/fritzcapabilities.py
+++ b/fritzexporter/fritzcapabilities.py
@@ -284,6 +284,23 @@ class WanCommonInterfaceDataBytes(FritzCapability):
         self.metrics['wanbytes'].add_metric([device.serial, 'down'], wan_bytes_rx)
         yield self.metrics['wanbytes']
 
+class WanCommonInterfaceByteRate(FritzCapability):
+    def __init__(self) -> None:
+        super().__init__()
+        self.requirements.append(('WANCommonIFC1', 'GetAddonInfos'))
+
+    def createMetrics(self):
+        self.metrics['wanbyterate'] = GaugeMetricFamily('fritz_wan_datarate', 'Current WAN data rate in bytes/s', labels=['serial', 'direction'], unit='bytes')
+
+    def _getMetricValues(self, device):
+        fritz_wan_result = device.fc.call_action('WANCommonIFC1', 'GetAddonInfos')
+        wan_byterate_rx = fritz_wan_result['NewByteReceiveRate']
+        wan_byterate_tx = fritz_wan_result['NewByteSendRate']
+        self.metrics['wanbyterate'].add_metric([device.serial, 'rx'], wan_byterate_rx)
+        self.metrics['wanbyterate'].add_metric([device.serial, 'tx'], wan_byterate_tx)
+        yield self.metrics['wanbyterate']
+
+
 class WanCommonInterfaceDataPackets(FritzCapability):
     def __init__(self) -> None:
         super().__init__()

--- a/fritzexporter/fritzcapabilities.py
+++ b/fritzexporter/fritzcapabilities.py
@@ -155,7 +155,7 @@ class UserInterface(FritzCapability):
     def _getMetricValues(self, device):
         update_result = device.fc.call_action('UserInterface:1', 'GetInfo')
         upd_available = 1 if update_result['NewUpgradeAvailable'] else 0
-        new_software_version = "n/a" if update_result['NewUpgradeAvailable'] else update_result['NewX_AVM-DE_Version']
+        new_software_version = update_result['NewX_AVM-DE_Version'] if update_result['NewUpgradeAvailable'] else 'n/a'
         self.metrics['update'].add_metric([device.serial, new_software_version], upd_available)
         yield self.metrics['update']
 


### PR DESCRIPTION
This adds new metrics for the current byterate on the WAN Interface., where available (fritz_wan_byterate).

Also documents, that the guest WiFi packet counter will always be "0", as the Fritz API always returns 0 for these counters.