### PR TITLE
[1.0.6] Also catch "FritzInternalError" when scanning capabilities

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -33,11 +33,11 @@
         },
         "fritzconnection": {
             "hashes": [
-                "sha256:13950067ef211b64a8e13ec90779d13cca67a7104e1e8080f5957638a1552181",
-                "sha256:f89905eaa0db740ad431fad3551f08ac3b0c23189b926b499116791029213127"
+                "sha256:093f4b6663cfd4e89af6d5402eb26cd13e4cfa5e8ddb3b80ca0bcb04abe5426b",
+                "sha256:b6376ea9608b44fdadcf434da19c98a689fddce458912ca3e9f42f7acd21bd25"
             ],
             "index": "pypi",
-            "version": "==1.4.0"
+            "version": "==1.4.2"
         },
         "idna": {
             "hashes": [
@@ -65,11 +65,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:1b465e494e3e0d8939b50680403e3aedaa2bc434b7d5af64dfd3c958d7f5ae80",
-                "sha256:de3eedaad74a2683334e282005cd8d7f22f4d55fa690a2a1020a416cb0a47e73"
+                "sha256:2f4da4594db7e1e110a944bb1b551fdf4e6c136ad42e4234131391e21eb5b0df",
+                "sha256:e7b021f7241115872f92f43c6508082facffbd1c048e3c6e2bb9c2a157e28937"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.26.3"
+            "version": "==1.26.4"
         }
     },
     "develop": {}

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ If there is any information missing or not displayed on your specific device, pl
 ## Known problems
 
 * It seems like Fritz!OS does not internally count the packets for the Guest WiFi. So even though those counters are there they are always 0. This seems to be a problem with Fritz!OS and not the exporter. The counters are delivered nontheless, just in case this gets fixed by AVM.
+* If you receive `Fatal Python error: init_interp_main: can't initialize time` when running the container you may have to update libseccomp on your Docker host. This issue mainly happens on Raspberry Pi and is triggered by a version of libseccomp2 which is too old. See <https://askubuntu.com/questions/1263284/apt-update-throws-signature-error-in-ubuntu-20-04-container-on-arm> (Method 2) and <https://github.com/pdreker/fritzbox_exporter/issues/38>
 
 ## Grafana Dashboard
 
@@ -110,7 +111,7 @@ Configuration is done via environment vars.
 
 The main configuration is done inside the environment variable `FRITZ_EXPORTER_CONFIG`. This variable must contain the comma-separated address, username and password for the device. If you need multiple devices simply repeat the three values for the other devices.
 
-An alternative it to use The three environment variables `FRITZ_HOSTNAME`, `FRITZ_USERNAME` and `FRITZ_PASSWORD`, This way you lose the ability to monitor multiple devices with one exporter but gain the ability To put `FRITZ_PASSWORD` into a kubernetes secret like shown in [Kubernetes deployment](#kubernetes-deployment).
+An alternative is to use The three environment variables `FRITZ_HOSTNAME`, `FRITZ_USERNAME` and `FRITZ_PASSWORD`, This way you lose the ability to monitor multiple devices with one exporter but gain the ability To put `FRITZ_PASSWORD` into a kubernetes secret like shown in [Kubernetes deployment](#kubernetes-deployment).
 
 Example for a single device (at 192.168.178.1 username monitoring and the password "mysupersecretpassword"):
 


### PR DESCRIPTION
Some boxes seem to report a capabilitiy, but when actually calling the action respond with `820 Internal Error`. The capability scanner will now also detect this and disable the metrics for affected boxes.