### PR TITLE
Add note about password length to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ If there is any information missing or not displayed on your specific device, pl
 * It seems like Fritz!OS does not internally count the packets for the Guest WiFi. So even though those counters are there they are always 0. This seems to be a problem with Fritz!OS and not the exporter. The counters are delivered nontheless, just in case this gets fixed by AVM.
 * If you receive `Fatal Python error: init_interp_main: can't initialize time` when running the container you may have to update libseccomp on your Docker host. This issue mainly happens on Raspberry Pi and is triggered by a version of libseccomp2 which is too old. See <https://askubuntu.com/questions/1263284/apt-update-throws-signature-error-in-ubuntu-20-04-container-on-arm> (Method 2) and <https://github.com/pdreker/fritzbox_exporter/issues/38>.
 * On some boxes LAN Packet counters are stuck at 0 even though the box reports the stats as available.
+* The Fritz!OS does not allow passwords longer than 32 characters (as of 07.22). If you try to insert a longer password, the admin ui will discard the 33rd character and all following. The UI will also cut your inserted password down to 32 characters. So you will be able to login with the long password. However, the exporter does not alter your password and requests will result in a 401 Unauthorized. So please be aware and choose a suitable password.
 
 ## Grafana Dashboard
 


### PR DESCRIPTION
Unfortunately I wasted two hours of my time since I did not notice that the Fritz!Box does not allow passwords longer than 32 characters. This pr adds a note about this unexpected behavior of the router to the README.md so that further users of this exporter will not run into the problem.

Just to clarify: I believe that the exporter behaves exactly as it should 👍 . However, I would like to add this note for documentation purposes so that other users will waste as much time as I did.

Thanks for creating the exporter 💪 .